### PR TITLE
ENH: Detect branch name from environment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,5 +55,5 @@ echo "Exporting to S3 bucket ..."
 datalad siblings -d ${GITHUB_REPOSITORY##*/}/ enable -s s3
 pushd ${GITHUB_REPOSITORY##*/}
 datalad get -r *
-git annex export master --to s3
+git annex export "${GITHUB_REF_NAME}" --to s3
 popd


### PR DESCRIPTION
I don't fully understand why `tpl-dhcpAsym` was created with default branch `master` and `tpl-dhcpSym` was created with default branch `main`, but oh well. We should assume that some templates will get created as `main` repos.

This change uses `$GITHUB_REF_NAME` (via https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) to export the relevant branch to S3.